### PR TITLE
Add a NOTICE file instead of Apache headers in individual files

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,13 @@
+Copyright 2021 Causal Incentives Working Group
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/examples/generate.py
+++ b/examples/generate.py
@@ -1,6 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor license
-# agreements; and to You under the Apache License, Version 2.0.
-
 import random
 from typing import List, Tuple
 

--- a/examples/simple_cids.py
+++ b/examples/simple_cids.py
@@ -1,6 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor license
-# agreements; and to You under the Apache License, Version 2.0.
-
 from pycid.core.cid import CID
 from pycid.core.cpd import DecisionDomain, FunctionCPD, UniformRandomCPD
 

--- a/pycid/core/cid.py
+++ b/pycid/core/cid.py
@@ -1,6 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor license
-# agreements; and to You under the Apache License, Version 2.0.
-
 from __future__ import annotations
 
 import random

--- a/pycid/core/cpd.py
+++ b/pycid/core/cpd.py
@@ -1,6 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor license
-# agreements; and to You under the Apache License, Version 2.0.
-
 from __future__ import annotations
 
 import itertools

--- a/pycid/core/get_paths.py
+++ b/pycid/core/get_paths.py
@@ -1,5 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor license
-# agreements; and to You under the Apache License, Version 2.0.
 from typing import List, Set, Tuple
 
 import networkx as nx

--- a/pycid/core/macid.py
+++ b/pycid/core/macid.py
@@ -1,5 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor license
-# agreements; and to You under the Apache License, Version 2.0.
 from __future__ import annotations
 
 import copy

--- a/pycid/core/macid_base.py
+++ b/pycid/core/macid_base.py
@@ -1,5 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor license
-# agreements; and to You under the Apache License, Version 2.0.
 from __future__ import annotations
 
 import itertools

--- a/test/test_cid.py
+++ b/test/test_cid.py
@@ -1,6 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor license
-# agreements; and to You under the Apache License, Version 2.0.
-# %%
 import logging
 import unittest
 

--- a/test/test_get_paths.py
+++ b/test/test_get_paths.py
@@ -1,5 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor license
-# agreements; and to You under the Apache License, Version 2.0.
 import logging
 import unittest
 

--- a/test/test_macid.py
+++ b/test/test_macid.py
@@ -1,6 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor license
-# agreements; and to You under the Apache License, Version 2.0.
-# %%
 import logging
 import unittest
 

--- a/test/test_macid_base.py
+++ b/test/test_macid_base.py
@@ -1,6 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor license
-# agreements; and to You under the Apache License, Version 2.0.
-# %%
 import logging
 import unittest
 

--- a/test/test_reasoning_patterns.py
+++ b/test/test_reasoning_patterns.py
@@ -1,6 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor license
-# agreements; and to You under the Apache License, Version 2.0.
-
 import unittest
 
 from pycid.analyze.reasoning_patterns import (


### PR DESCRIPTION
* ~LICENSE just contains a short notice and a reference to the full license.
    This is what Apache suggests in "How to apply the Apache license to your work"
    https://www.apache.org/licenses/LICENSE-2.0~

* Added NOTICE file
* Removed notification headers from .py files.
    These were possibly incorrect anyway since they say the code was directly licensed to The Apache Software Foundation under a CLA.