### PR TITLE
Change flake8 from "gitlab" to "github"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.8.4
     hooks:
       - id: flake8


### PR DESCRIPTION
I noticed that the gitlab link was broken and changed this to "github" for the pre-commits to work. I don't expect any behaviour change from this (except that it now doesn't break).